### PR TITLE
Fixed problem with saving

### DIFF
--- a/spec_augment/spec_augment.py
+++ b/spec_augment/spec_augment.py
@@ -111,6 +111,6 @@ class SpecAugment(Layer):
             "T": self.time_mask_param,
             "mF": self.n_freq_mask,
             "mT": self.n_time_mask,
-            "mask_value": self.input_mask_value
+            "mask_value": self.mask_value.numpy(),
         }
         return config


### PR DESCRIPTION
The `mask_value` in the configuration referenced a missing variable, thus when saving a model with the layer it failed. This fixes the problem.