### PR TITLE
But in serializing/deserializing the layer

### DIFF
--- a/spec_augment/spec_augment.py
+++ b/spec_augment/spec_augment.py
@@ -107,10 +107,10 @@ class SpecAugment(Layer):
         :return:
         """
         config = {
-            "F": self.freq_mask_param,
-            "T": self.time_mask_param,
-            "mF": self.n_freq_mask,
-            "mT": self.n_time_mask,
+            "freq_mask_param": self.freq_mask_param,
+            "time_mask_param": self.time_mask_param,
+            "n_freq_mask": self.n_freq_mask,
+            "n_time_mask": self.n_time_mask,
             "mask_value": self.mask_value.numpy(),
         }
         return config


### PR DESCRIPTION
Layer wasn't able to be saved and reloaded due to wrong naming in the `get_config` definition.

This code tests if the layer can be serialized and deserialized, i.e. saved and loaded.
```python
serialized_layer = tf.keras.layers.serialize(SpecAugment(1,1))
new_layer = tf.keras.layers.deserialize(
    serialized_layer, custom_objects={"SpecAugment": SpecAugment}
)
```